### PR TITLE
Converting MQM spans into ESA format

### DIFF
--- a/humeval/calculate_clusters.py
+++ b/humeval/calculate_clusters.py
@@ -45,7 +45,7 @@ def main(argv):
         df = attach_resources(df)
         # save pickle
         df.to_pickle('cache.pkl')
-        df.to_csv('full_export.csv')
+        df.to_csv('full_export.csv', index=None)
 
     # if there are multiple ratings for the same segment, average them
     subdf = df.groupby(['annot_id', 'lp', 'system_id', 'orig_segment_id'])

--- a/humeval/tools.py
+++ b/humeval/tools.py
@@ -87,6 +87,7 @@ def apply_conversion(row):
     if x['category'] == 'Accuracy/Omission':
       spans = [(len(clean_text)+1, len(clean_text)+1+len(['MISSING']))]
     if not spans:
+      # source error and other category dont mark target span
       return f"{{'start_i': 0, 'end_i': 0, 'severity': '{severity.lower()}', 'error_type': '{category.lower()}'}}"
     else:
       return f"{{'start_i': {spans[0][0]}, 'end_i': {spans[0][1]}, 'severity': '{severity.lower()}', 'error_type': '{category.lower()}'}}"


### PR DESCRIPTION
The changes convert Google MQM spans marked on the target in <v></v> format to error spans format returned by ESA. Omission is handled by marking the span in a special missing token at the end of the target sequence. Source Issue and Other don't have spans marked. 